### PR TITLE
Update embed.js

### DIFF
--- a/embed.js
+++ b/embed.js
@@ -14,7 +14,7 @@ class Strudel extends HTMLElement {
       const src = `https://strudel.tidalcycles.org/#${encodeURIComponent(btoa(code))}`;
       // const src = `http://localhost:3000/#${encodeURIComponent(btoa(code))}`;
       iframe.setAttribute('src', src);
-      iframe.setAttribute('width', '548');
+      iframe.setAttribute('width', '100%');
       iframe.setAttribute('height', '300');
       this.appendChild(iframe);
 


### PR DESCRIPTION
using 100% width instead should make this more flexible. on my mastodon instance (post.lurk.org) the width is smaller, so 548 cuts off characters on the right.. I've tried setting 100% within dev tools and it seems to work.. 

 Btw thanks for this cool extension! I am thinking about adding a dedicated route for embedding the repl e.g. strudel.tidalcycles.org/embed to allow getting a better look. would be nice if the bg color matched mastodon , also the buttons could be more minimalistic